### PR TITLE
Level resets when you run out of cards

### DIFF
--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -45,6 +45,7 @@ public class GameManager : MonoBehaviour
     private UIManager _uiManager;
 
     public STATE gameState;
+    private bool _gameWon;
 
     private LevelDeck _levelDeck;
     private List<Card> _deck;
@@ -158,6 +159,7 @@ public class GameManager : MonoBehaviour
             case STATE.End:
                 gameState = STATE.End;
                 //Add method here if needed
+                _gameWon = true;
                 Invoke("LoadLevelSelect", 1);
                 break;
             default:
@@ -228,8 +230,8 @@ public class GameManager : MonoBehaviour
             _deck = _deckManagerCard.RemoveFirst(_deck); //Removes the now dealt card from the deck
         }
 
-        //If out of cards, go to corresponding game state
-        if (_dealtCards.Count == 0 && _deck.Count == 0)
+        //If out of cards, go to corresponding game state AND IF NOT ALREADY WON
+        if (_dealtCards.Count == 0 && _deck.Count == 0 && !_gameWon)
         {
             ChangeGameState(STATE.OutOfCards);
         }

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -315,6 +315,7 @@ public class GameManager : MonoBehaviour
     /// </summary>
     private void OutOfCards()
     {
+        ChangeGameState(STATE.Death);
         print("Skill Issue."); //TODO - Replace this with actual functionality
     }
 


### PR DESCRIPTION
To test, go into any level scenes and remve all but one card from the level deck. play the level and check that the game resets when you play that card. 

Also test a level normally, with all its cards, ensure that when the level is won that it loads the level select menu.

I had to add a bool in the game manager for when the level was won because the game state still moved on to the card select state before the end state was finished so I couldn't check the game state to see if the player had run out of cards or if they had won.