### PR TITLE
Player ghost preview

### DIFF
--- a/Assets/Prefabs/FinishFlag.prefab
+++ b/Assets/Prefabs/FinishFlag.prefab
@@ -64,5 +64,5 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
+  m_Size: {x: 0.25, y: 1, z: 0.25}
   m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/PlayerContainer.prefab
+++ b/Assets/Prefabs/PlayerContainer.prefab
@@ -1,5 +1,120 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &217780371117460655
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2925217296595416114}
+  m_Layer: 0
+  m_Name: PlayerRaycastPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2925217296595416114
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 217780371117460655}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3283924478590826376}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2790596725505949022
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5267040300578080311}
+  - component: {fileID: 2510186299653995690}
+  - component: {fileID: 6752944203483893062}
+  m_Layer: 0
+  m_Name: PlayerObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5267040300578080311
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2790596725505949022}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2699278325131370560}
+  m_Father: {fileID: 3283924478590826376}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2510186299653995690
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2790596725505949022}
+  m_Mesh: {fileID: -8908299743826163017, guid: 346e1fe86f37f464a92ff4b4afbb7046, type: 3}
+--- !u!23 &6752944203483893062
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2790596725505949022}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 3532ce8c548b26a4b982845b557470fd, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3075914246164915663
 GameObject:
   m_ObjectHideFlags: 0
@@ -198,6 +313,288 @@ Transform:
   m_Children: []
   m_Father: {fileID: 6253370473978591665}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4146704754806170629
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3283924478590826376}
+  - component: {fileID: 6248828582279176098}
+  - component: {fileID: 6816313960352691394}
+  - component: {fileID: 2924195812671290854}
+  m_Layer: 0
+  m_Name: PlayerGhost
+  m_TagString: PlayerGhost
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3283924478590826376
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4146704754806170629}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5267040300578080311}
+  - {fileID: 2925217296595416114}
+  m_Father: {fileID: 6253370473978591665}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &6248828582279176098
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4146704754806170629}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.4
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &6816313960352691394
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4146704754806170629}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 112
+  m_CollisionDetection: 0
+--- !u!114 &2924195812671290854
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4146704754806170629}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3fc3340d301d1c94b991a32cc0856cf9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _currentFacingDirection: 1
+  _checkMoveInterval: 0.1
+  _jumpArcHeight: 4
+  _checkInterval: 0.05
+  _rayCastDistance: 3
+  _raycastPoint: {fileID: 2925217296595416114}
+  _currentTile: {fileID: 0}
+  _moveEaseCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  _jumpEaseCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  _fallEaseCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 1
+      outSlope: 1
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 1
+      outSlope: 1
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  _turnEaseCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!1 &8728325800967980400
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2699278325131370560}
+  - component: {fileID: 2845295402500062669}
+  - component: {fileID: 8715986527396747055}
+  m_Layer: 0
+  m_Name: Eyes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2699278325131370560
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8728325800967980400}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0.9961947, z: -0.08715578, w: 0}
+  m_LocalPosition: {x: -0.425, y: -0.25, z: 0.5}
+  m_LocalScale: {x: 1, y: 1, z: 0.75}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5267040300578080311}
+  m_LocalEulerAnglesHint: {x: 10, y: 180, z: 0}
+--- !u!33 &2845295402500062669
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8728325800967980400}
+  m_Mesh: {fileID: 3921568967233161584, guid: 346e1fe86f37f464a92ff4b4afbb7046, type: 3}
+--- !u!23 &8715986527396747055
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8728325800967980400}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 3a145edf04c2a13468ba0c1817c68d67, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &8738298236461623606
 GameObject:
   m_ObjectHideFlags: 0
@@ -233,6 +630,7 @@ Transform:
   m_Children:
   - {fileID: 6277560721660886548}
   - {fileID: 4540641159670852829}
+  - {fileID: 3283924478590826376}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!135 &5090448011150464352

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -69,7 +69,7 @@ public class PlayerController : MonoBehaviour
 
             if (checkTimeElapsed >= _checkInterval)
             {
-                if (GetTileWithPlayerRaycast() != previousTile)
+                if (GetTileWithPlayerRaycast() != previousTile && GetTileWithPlayerRaycast() != null)
                 {
                     previousTile = GetTileWithPlayerRaycast();
                     if (previousTile.IsHole()) //player needs to fall down

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -34,9 +34,7 @@ public class PlayerController : MonoBehaviour
 
     public void Start()
     {
-        //_currentTile = TileManager.Instance.GetTileByCoordinates(_currentTile.GetCoordinates());
-        transform.position = _currentTile.GetPlayerSnapPosition();
-        //TODO : replace this with a more concrete way to set the starting position
+
     }
     void Update()
     {
@@ -57,7 +55,6 @@ public class PlayerController : MonoBehaviour
         float checkTimeElapsed = 0f;
 
         Tile previousTile = _currentTile;
-        bool changedDestination = false;
 
         //get the last key in the curve
         while (timeElapsed < _moveEaseCurve.keys[_moveEaseCurve.length - 1].time)

--- a/Assets/Scripts/StateMachine/PlayerStateMachineBrain.cs
+++ b/Assets/Scripts/StateMachine/PlayerStateMachineBrain.cs
@@ -24,16 +24,17 @@ using UnityEngine;
 
 public class PlayerStateMachineBrain : MonoBehaviour
 {
-
     [SerializeField] private State _currentState;
     private Coroutine _currentStateCoroutine;
     private Card _currentAction;
     private List<Card> _actions = new List<Card>();
+    private List<Card> _actionCopies = new List<Card>();
     private Tile _targetTile;
-    private GameObject _player;
-    private PlayerController _pC;
+    private GameObject _player, _ghostPlayer;
+    private PlayerController _currentPlayerController, _playerControllerOriginal, _playerControllerGhost;
     private int _distance;
     private bool _firedTraps = false;
+    private bool _isGhost = false;
     
     public void Start()
     {
@@ -42,10 +43,16 @@ public class PlayerStateMachineBrain : MonoBehaviour
         PlayerController.SpikeCollision += HandleSpikeInterruption;
         PlayerController.WallInterruptAnimation += HandleWallInterruption;
         GameManager.PlayActionOrder += HandleIncomingActions;
+        GameManager.PlayDemoActionOrder += HandleIncomingGhostActions;
         TileManager.Instance.LoadTileList();
         TileManager.Instance.LoadObstacleList();
         FindPlayer();
+        _player.transform.position = _playerControllerOriginal.GetCurrentTile().GetPlayerSnapPosition();
         //TODO: Have something else load the tileList()
+    }
+    public void Update()
+    {
+
     }
 
     /// <summary>
@@ -121,14 +128,16 @@ public class PlayerStateMachineBrain : MonoBehaviour
                 break;
         }
     }
-
     public void FindPlayer()
     {
         if (_player == null)
         {
             _player = GameObject.FindGameObjectWithTag("Player");
-            _pC = GetPlayerController();
-            if (_pC == null)
+            _currentPlayerController= _playerControllerOriginal = _player.GetComponent<PlayerController>();
+            _ghostPlayer = GameObject.FindGameObjectWithTag("PlayerGhost");
+            _playerControllerGhost = _ghostPlayer.GetComponent<PlayerController>();
+
+            if (_currentPlayerController == null)
             {
                 print("NULL");
             }
@@ -136,6 +145,19 @@ public class PlayerStateMachineBrain : MonoBehaviour
             {
                 Debug.Log("No gameobject in scene tagged with player");
             }
+        }
+    }
+    public void SetGhostState(bool isGhost)
+    {
+        if(!isGhost)
+        {
+            _isGhost = false;
+            _currentPlayerController = _playerControllerOriginal;
+        }
+        else
+        {
+            _isGhost = true;
+            _currentPlayerController = _playerControllerGhost;
         }
     }
     public Card GetNextAction()
@@ -152,25 +174,7 @@ public class PlayerStateMachineBrain : MonoBehaviour
     {
         return _currentState;
     }
-    public PlayerController GetPlayerController()
-    {
-        if (_pC != null)
-        {
-            return _pC;
-        }
-        return GetPlayer().GetComponent<PlayerController>();
-    }
-    public GameObject GetPlayer()
-    {
-        if (_player != null)
-        {
-            return _player;
-        }
-        {
-            FindPlayer();
-            return _player;
-        }
-    }
+
 
     public void HandleCardAdd(Card card)
     {
@@ -178,32 +182,58 @@ public class PlayerStateMachineBrain : MonoBehaviour
     }
     public void HandleIncomingActions(List<Card> cardList)
     {
+        //_currentPlayerController.SetCurrentTile(_playerControllerOriginal.GetCurrentTile());
+        //_currentPlayerController.SetFacingDirection(_playerControllerOriginal.GetCurrentFacingDirection());
+
+        //_ghostPlayer.SetActive(false); //turn off the ghost gameobject
+        //_currentPlayerController.StopAllCoroutines(); //stop whatever ghost is doing
+        //SetGhostState(false); //change the selected player script back to player from ghost
+        //_ghostPlayer.transform.position = Vector3.zero; //make sure the ghost goes back to the parent
+
+        //_firedTraps = false;
+        //StartCardActions(cardList);
+    }
+    public void HandleIncomingGhostActions(List<Card> cardList)
+    {
+        _currentPlayerController.SetCurrentTile(_playerControllerOriginal.GetCurrentTile());
+        _currentPlayerController.SetFacingDirection(_playerControllerOriginal.GetCurrentFacingDirection());
+        SetGhostState(true);
         StartCardActions(cardList);
+        print(cardList.Count);
     }
     public void HandleWallInterruption()
     {
-        if (_pC.GetCurrentMovementCoroutine() != null)
+        if (_currentPlayerController.GetCurrentMovementCoroutine() != null)
         {
-            _pC.StopCoroutine(_pC.GetCurrentMovementCoroutine());
+            _currentPlayerController.StopCoroutine(_currentPlayerController.GetCurrentMovementCoroutine());
             //_pC.StartFallCoroutine(transform.position, _pC.GetCurrentTile().GetPlayerSnapPosition());
         }
         FSM(State.PrepareNextAction);
     }
     public void HandleSpikeInterruption()
     {
-        if (_pC.GetCurrentMovementCoroutine() != null)
+        if (_currentPlayerController.GetCurrentMovementCoroutine() != null)
         {
-            _pC.StopCoroutine(_pC.GetCurrentMovementCoroutine());
+            _currentPlayerController.StopCoroutine(_currentPlayerController.GetCurrentMovementCoroutine());
         }
         FSM(State.WaitingForActions);
     }
     public void HandleReachedDestination()
     {
-        if(_pC.GetCurrentMovementCoroutine() != null)
+        if(_currentPlayerController.GetCurrentMovementCoroutine() != null)
         {
-            _pC.StopCoroutine(_pC.GetCurrentMovementCoroutine());
+            _currentPlayerController.StopCoroutine(_currentPlayerController.GetCurrentMovementCoroutine());
         }
 
+        FSM(State.PrepareNextAction);
+    }
+    /// <summary>
+    /// The method used to start a new action order from outside scripts
+    /// </summary>
+    /// <param name="incomingActions"></param>
+    public void StartCardActions(List<Card> incomingActions)
+    {
+        SetCardList(incomingActions);
         FSM(State.PrepareNextAction);
     }
     public void SetCardList(List<Card> incomingActions)
@@ -212,6 +242,7 @@ public class PlayerStateMachineBrain : MonoBehaviour
         if(incomingActions != null)
         {
             _actions.AddRange(incomingActions);
+            _actionCopies.AddRange(incomingActions); //for ghost repeating
         }
     }
 
@@ -231,16 +262,7 @@ public class PlayerStateMachineBrain : MonoBehaviour
         }
     }
 
-    /// <summary>
-    /// The method used to start a new action order from outside scripts
-    /// </summary>
-    /// <param name="incomingActions"></param>
-    public void StartCardActions(List<Card> incomingActions)
-    {
-        _firedTraps = false;
-        SetCardList(incomingActions);
-        FSM(State.PrepareNextAction);
-    }
+
 
     private IEnumerator PrepareNextAction()
     {
@@ -249,11 +271,16 @@ public class PlayerStateMachineBrain : MonoBehaviour
             _currentAction = GetNextAction();
             if (_currentAction != null)
             {
+                print("here");
                 FSM(State.FindTileUponAction);
             }
-            else if(!_firedTraps)
+            else if (!_firedTraps)
             {
                 FSM(State.TrapPlayState);
+            }
+            else if (_currentAction != null && _isGhost)
+            {
+                StartCardActions(_actionCopies); //restart the preview until the true cards come in
             }
             else
             {
@@ -267,22 +294,22 @@ public class PlayerStateMachineBrain : MonoBehaviour
     {
         while (_currentState == State.FindTileUponAction)
         {
-            var currentTile = _pC.GetCurrentTile();
+            var currentTile = _currentPlayerController.GetCurrentTile();
 
             _distance = _currentAction.GetDistance(); //main focus of this state
 
-            int facingDirection = _pC.GetCurrentFacingDirection();
-            if (_pC.GetCurrentTile().GetObstacleClass() != null) //If youre standing on an obstacle that sends you in a direction
+            int facingDirection = _currentPlayerController.GetCurrentFacingDirection();
+            if (_currentPlayerController.GetCurrentTile().GetObstacleClass() != null) //If youre standing on an obstacle that sends you in a direction
             {
                
-                facingDirection = _pC.GetCurrentTile().GetObstacleClass().GetDirection();
+                facingDirection = _currentPlayerController.GetCurrentTile().GetObstacleClass().GetDirection();
                 if(facingDirection == 4) //IF the tile doesnt have a facing direction, use the player's current FD
                 {
-                    facingDirection = _pC.GetCurrentFacingDirection();
+                    facingDirection = _currentPlayerController.GetCurrentFacingDirection();
                 }
                 if(_currentAction.name != Card.CardName.Jump)
                 {
-                    _pC.SetFacingDirection(facingDirection); //turn the player to face where they are going
+                    _currentPlayerController.SetFacingDirection(facingDirection); //turn the player to face where they are going
                 }               
             }
 
@@ -304,14 +331,14 @@ public class PlayerStateMachineBrain : MonoBehaviour
                     SfxManager.Instance.PlaySFX(2469);
                     //_pC.TurnPlayer(true);
                     //PlayerController.ReachedDestination?.Invoke();
-                    _pC.StartTurnCoroutine(true);
+                    _currentPlayerController.StartTurnCoroutine(true);
                     //TODO: listen for wait for turn player animation event 
                     break;
                 case Card.CardName.TurnRight:
                     SfxManager.Instance.PlaySFX(2469);
                     //_pC.TurnPlayer(false);
                     //PlayerController.ReachedDestination?.Invoke();
-                    _pC.StartTurnCoroutine(false);
+                    _currentPlayerController.StartTurnCoroutine(false);
                     //TODO: animation here
                     break;
                 case Card.CardName.Jump:
@@ -327,19 +354,19 @@ public class PlayerStateMachineBrain : MonoBehaviour
                         //    _targetTile = TileManager.Instance.GetTileAtLocation //TODO: must change from random to targetdirection or direction of targettile
                         //(_pC.GetCurrentTile(), possibleNumbers[randomIndex], _distance);
 
-                        _pC.StartJumpCoroutine(_pC.GetCurrentTile().GetPlayerSnapPosition(), _targetTile.GetPlayerSnapPosition());
+                        _currentPlayerController.StartJumpCoroutine(_currentPlayerController.GetCurrentTile().GetPlayerSnapPosition(), _targetTile.GetPlayerSnapPosition());
                     }
 
                     else // this is a normal jump
                     {
                         SfxManager.Instance.PlaySFX(3740);
                         //determine result by getting difference of elevation betwen current tile and tile right in front of player
-                        _distance += (_pC.GetCurrentTile().GetElevation() - 
-                            (TileManager.Instance.GetTileAtLocation(_pC.GetCurrentTile(), _pC.GetCurrentFacingDirection(), 1).GetElevation()));
+                        _distance += (_currentPlayerController.GetCurrentTile().GetElevation() - 
+                            (TileManager.Instance.GetTileAtLocation(_currentPlayerController.GetCurrentTile(), _currentPlayerController.GetCurrentFacingDirection(), 1).GetElevation()));
                         if (_distance < 0) //block is too high
                         {
                             Vector3 newVector = (_targetTile.GetPlayerSnapPosition());
-                            _pC.StartJumpCoroutine(_pC.GetCurrentTile().GetPlayerSnapPosition(), new Vector3(newVector.x, newVector.y - 1, newVector.z));
+                            _currentPlayerController.StartJumpCoroutine(_currentPlayerController.GetCurrentTile().GetPlayerSnapPosition(), new Vector3(newVector.x, newVector.y - 1, newVector.z));
                         }
                         else //block isnt too tall; need to add distance if 0 to actually jump onto the next block
                         {
@@ -347,15 +374,15 @@ public class PlayerStateMachineBrain : MonoBehaviour
                             {
                                 _distance++;
                             }
-                            _pC.StartJumpCoroutine(_pC.GetCurrentTile().GetPlayerSnapPosition(), 
-                                TileManager.Instance.GetTileAtLocation(_pC.GetCurrentTile(), _pC.GetCurrentFacingDirection(), _distance).GetPlayerSnapPosition());
+                            _currentPlayerController.StartJumpCoroutine(_currentPlayerController.GetCurrentTile().GetPlayerSnapPosition(), 
+                                TileManager.Instance.GetTileAtLocation(_currentPlayerController.GetCurrentTile(), _currentPlayerController.GetCurrentFacingDirection(), _distance).GetPlayerSnapPosition());
                         }
                     }
                     break;
                 case Card.CardName.Move:
                     SfxManager.Instance.PlaySFX(9754);
-                    Vector3 newV = new Vector3(_targetTile.GetPlayerSnapPosition().x, _pC.transform.position.y, _targetTile.GetPlayerSnapPosition().z);
-                    _pC.StartMoveCoroutine(_pC.GetCurrentTile().GetPlayerSnapPosition(), newV);
+                    Vector3 newV = new Vector3(_targetTile.GetPlayerSnapPosition().x, _currentPlayerController.transform.position.y, _targetTile.GetPlayerSnapPosition().z);
+                    _currentPlayerController.StartMoveCoroutine(_currentPlayerController.GetCurrentTile().GetPlayerSnapPosition(), newV);
                     break;
             }
             yield return null;
@@ -379,9 +406,9 @@ public class PlayerStateMachineBrain : MonoBehaviour
             yield return new WaitForSeconds(1);
             GameManager.TrapAction?.Invoke();
             _firedTraps = true;
-            if (_pC.GetTileWithPlayerRaycast().GetObstacleClass() != null)
+            if (_currentPlayerController.GetTileWithPlayerRaycast().GetObstacleClass() != null)
             {
-                AddCardToList(_pC.GetTileWithPlayerRaycast().GetObstacleClass().GetCard());
+                AddCardToList(_currentPlayerController.GetTileWithPlayerRaycast().GetObstacleClass().GetCard());
             }
             FSM(State.PrepareNextAction);
         }
@@ -394,5 +421,6 @@ public class PlayerStateMachineBrain : MonoBehaviour
         PlayerController.SpikeCollision -= HandleSpikeInterruption;
         PlayerController.WallInterruptAnimation -= HandleWallInterruption;
         GameManager.PlayActionOrder -= HandleIncomingActions;
+        GameManager.PlayDemoActionOrder -= HandleIncomingGhostActions;
     }
 }

--- a/Assets/Scripts/TileSystem/DeathBox.cs
+++ b/Assets/Scripts/TileSystem/DeathBox.cs
@@ -4,11 +4,18 @@ public class DeathBox : MonoBehaviour
 {
     private void OnTriggerEnter(Collider other)
     {
-        PlayerController player = other.GetComponent<PlayerController>();
-        if (player != null)
+        if(other.CompareTag("Player"))
         {
-            print("DIED");
             GameManager.Instance.ChangeGameState(GameManager.STATE.Death);
+        }
+        else if(other.CompareTag("PlayerGhost"))
+        {
+            PlayerStateMachineBrain psmb = other.gameObject.GetComponentInParent<PlayerStateMachineBrain>(true);
+            while(psmb.GetNextAction() != null) //removes all remaining actions
+            {
+
+            }
+            PlayerController.ReachedDestination?.Invoke();
         }
     }
 }

--- a/Assets/Scripts/TileSystem/FinishFlag.cs
+++ b/Assets/Scripts/TileSystem/FinishFlag.cs
@@ -18,7 +18,8 @@ public class FinishFlag : Collectable
     }
     private IEnumerator WaitCoroutine()
     {
-        _PSMB.SetCardList(null);
+        //_PSMB.SetCardList(null);
+        _PSMB.StartCardActions(null);
         yield return new WaitForSeconds(1);
         GameManager.Instance.ChangeGameState(GameManager.STATE.End);
         print("WIN");

--- a/Assets/Scripts/TileSystem/FinishFlag.cs
+++ b/Assets/Scripts/TileSystem/FinishFlag.cs
@@ -15,12 +15,21 @@ public class FinishFlag : Collectable
             _PSMB = other.GetComponent<PlayerStateMachineBrain>();
             StartCoroutine(WaitCoroutine());
         }
+        else if (other.CompareTag("PlayerGhost"))
+        {
+            PlayerStateMachineBrain psmb = other.gameObject.GetComponentInParent<PlayerStateMachineBrain>(true);
+            while (psmb.GetNextAction() != null) //removes all remaining actions
+            {
+
+            }
+            PlayerController.ReachedDestination?.Invoke();
+        }
     }
     private IEnumerator WaitCoroutine()
     {
         //_PSMB.SetCardList(null);
         _PSMB.StartCardActions(null);
-        yield return new WaitForSeconds(1);
+        yield return new WaitForSeconds(.75f);
         GameManager.Instance.ChangeGameState(GameManager.STATE.End);
         print("WIN");
     }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - Wall
+  - PlayerGhost
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Created the ghost player as a exact copy child of the main player, only without the PSMB and with a GhostTag

To test, make sure ghost player in the level you are in has a reference to the starting tile. Design/another PR for messing with the scenes to fix that. You should be able to see a smaller "ghost" version of the player before each confirm after a card is placed.

Bugs: -Preview continues after you deselect a card until a new card is selected
          -In order to see turning, i turned off the main player mesh until we decide how best to tackle that issue.

Minor changes to other scripts that depended on the "Player" specific tag
Major Player prefab changes
Added a GhostTag

