### PR TITLE
fixed duplication glitch

### DIFF
--- a/Assets/Scripts/ConfirmationControls.cs
+++ b/Assets/Scripts/ConfirmationControls.cs
@@ -43,6 +43,7 @@ public class ConfirmationControls : MonoBehaviour
     {
         if (isConfirmationPressedDown && mouseInConfirmationButton && isActive)
         {
+            isActive = false;
             isConfirmationPressedDown = false;
             _gameManager.ConfirmCards();
         }
@@ -70,6 +71,7 @@ public class ConfirmationControls : MonoBehaviour
     {
         if (isCancelPressedDown && mouseInCancelButton && isActive)
         {
+            isActive = false;
             isCancelPressedDown = false;
             _uiManager.DestroyConfirmCard();
             _gameManager.CancelCard();


### PR DESCRIPTION
ActionOrderBranch in any scene
Accidently created it when I was rewiring how everything worked to make the predict function or when I was making the clear and switch card appear and making the "animation" (I think)