### PR TITLE
Spring Fix

### DIFF
--- a/Assets/Prefabs/Game Prefabs/PlayerContainer.prefab
+++ b/Assets/Prefabs/Game Prefabs/PlayerContainer.prefab
@@ -160,7 +160,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _currentFacingDirection: 1
   _jumpArcHeight: 4
-  _checkInterval: 1
+  _checkInterval: 0.75
   _rayCastDistance: 3
   _forwardCastDistance: 0.05
   _raycastPoint: {fileID: 2925217296595416114}
@@ -362,7 +362,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _currentFacingDirection: 1
   _jumpArcHeight: 4
-  _checkInterval: 1
+  _checkInterval: 0.75
   _rayCastDistance: 3
   _forwardCastDistance: 0.05
   _raycastPoint: {fileID: 4540641159670852829}

--- a/Assets/Prefabs/Game Prefabs/PlayerContainer.prefab
+++ b/Assets/Prefabs/Game Prefabs/PlayerContainer.prefab
@@ -160,7 +160,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _currentFacingDirection: 1
   _jumpArcHeight: 4
-  _checkInterval: 0.75
+  _checkInterval: 0.1
   _rayCastDistance: 3
   _forwardCastDistance: 0.05
   _raycastPoint: {fileID: 2925217296595416114}
@@ -362,7 +362,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _currentFacingDirection: 1
   _jumpArcHeight: 4
-  _checkInterval: 0.75
+  _checkInterval: 0.1
   _rayCastDistance: 3
   _forwardCastDistance: 0.05
   _raycastPoint: {fileID: 4540641159670852829}

--- a/Assets/Scripts/Controls/PlayerController.cs
+++ b/Assets/Scripts/Controls/PlayerController.cs
@@ -105,7 +105,7 @@ public class PlayerController : MonoBehaviour
                         Vector3 newV = nextTile.GetPlayerSnapPosition();
                         StartFallCoroutine(transform.position, new Vector3(newV.x, newV.y - 10, newV.z));
                     }
-                    else if (nextTile.GetElevation() < _currentTile.GetElevation()) // going down an elevation level
+                    else if (nextTile.GetElevation() < _currentTile.GetElevation() && !nextTile.IsHole()) // going down an elevation level
                     {
                         StopCoroutine(_currentMovementCoroutine);
                         StartFallCoroutine(transform.position, nextTile.GetPlayerSnapPosition());

--- a/Assets/Scripts/StateMachine/PlayerStateMachineBrain.cs
+++ b/Assets/Scripts/StateMachine/PlayerStateMachineBrain.cs
@@ -409,8 +409,9 @@ public class PlayerStateMachineBrain : MonoBehaviour
             _firedTraps = true;
             if (_currentPlayerController.GetTileWithPlayerRaycast() != null && _currentPlayerController.GetTileWithPlayerRaycast().GetObstacleClass() != null)
             {
+                var temp = _currentPlayerController.GetTileWithPlayerRaycast().GetObstacleClass().GetCard();
                 //get card and check if its not a turn tables
-                if (_currentAction != null && (_currentAction.name != Card.CardName.TurnLeft && _currentAction.name != Card.CardName.TurnRight))
+                if (temp != null && (temp.name != Card.CardName.TurnLeft && temp.name != Card.CardName.TurnRight))
                 {
                     AddCardToList(_currentPlayerController.GetTileWithPlayerRaycast().GetObstacleClass().GetCard());
                 }

--- a/Assets/Scripts/StateMachine/PlayerStateMachineBrain.cs
+++ b/Assets/Scripts/StateMachine/PlayerStateMachineBrain.cs
@@ -407,7 +407,8 @@ public class PlayerStateMachineBrain : MonoBehaviour
             yield return new WaitForSeconds(.75f);
             GameManager.TrapAction?.Invoke();
             _firedTraps = true;
-            if (_currentPlayerController.GetTileWithPlayerRaycast() != null && _currentPlayerController.GetTileWithPlayerRaycast().GetObstacleClass() != null)
+            var tile = _currentPlayerController.GetTileWithPlayerRaycast();
+            if (tile != null && tile.GetObstacleClass() != null && tile.GetObstacleClass().IsActive())
             {
                 var temp = _currentPlayerController.GetTileWithPlayerRaycast().GetObstacleClass().GetCard();
                 //get card and check if its not a turn tables


### PR DESCRIPTION
Made sure the player was getting the card under it during the trap state. Also updated the players check interval to be slightly less to ensure no animations and tiles were skipped.
I could have sworn it was working before just fine during the trap state, so I'm a little concerned that this is popping up now. However, on level 5 18, the spring does fire for the trap state, so it appears fixed. We need more testing to make sure other instances like this aren't a problem, or that this caused another issue.