### PR TITLE
Bugs And Scenes

### DIFF
--- a/Assets/Prefabs/Game Prefabs/PlayerContainer.prefab
+++ b/Assets/Prefabs/Game Prefabs/PlayerContainer.prefab
@@ -160,7 +160,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _currentFacingDirection: 1
   _jumpArcHeight: 4
-  _checkInterval: 1
+  _checkInterval: 0.1
   _rayCastDistance: 3
   _forwardCastDistance: 0.05
   _raycastPoint: {fileID: 2925217296595416114}
@@ -362,7 +362,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _currentFacingDirection: 1
   _jumpArcHeight: 4
-  _checkInterval: 1
+  _checkInterval: 0.1
   _rayCastDistance: 3
   _forwardCastDistance: 0.05
   _raycastPoint: {fileID: 4540641159670852829}

--- a/Assets/Scripts/Controls/PlayerController.cs
+++ b/Assets/Scripts/Controls/PlayerController.cs
@@ -78,7 +78,7 @@ public class PlayerController : MonoBehaviour
     {
         float timeElapsed = 0f;
         float checkTimeElapsed = 0f;
-
+        Card cardOnTile = null;
         Tile nextTile = _currentTile;
 
         PlayAnimation("Forward");
@@ -112,22 +112,12 @@ public class PlayerController : MonoBehaviour
                     }
                     else if (nextTile.GetObstacleClass() != null && nextTile.GetObstacleClass().IsActive()) //runs atop an active obstacle
                     {
-                        var card = TileManager.Instance.GetObstacleWithTileCoordinates(nextTile.GetCoordinates()).GetCard();
-                        SetCurrentTile(TileManager.Instance.GetTileByCoordinates(nextTile.GetCoordinates()));
-
-
+                        
+                        //SetCurrentTile(TileManager.Instance.GetTileByCoordinates(nextTile.GetCoordinates()));
+                        targetTileLoc = nextTile.GetPlayerSnapPosition();
+                        cardOnTile = TileManager.Instance.GetObstacleWithTileCoordinates(nextTile.GetCoordinates()).GetCard();
                         //if not a turntable
-                        if (card != null && (card.name != Card.CardName.TurnLeft && card.name != Card.CardName.TurnRight))
-                        {
-                            StopCoroutine(_currentMovementCoroutine);
-                            AddCard?.Invoke(card);
-                            nextTile.GetObstacleClass().PerformObstacleAnim();
-                            ReachedDestination?.Invoke();
-                        }
-                        //else if (card != null)
-                        //{
-                        //    AddCard?.Invoke(card);
-                        //}
+
                     }
                 }
                 // Reset the check timer
@@ -138,7 +128,14 @@ public class PlayerController : MonoBehaviour
 
         transform.position = targetTileLoc; //double check final position
         SetCurrentTile(TileManager.Instance.GetTileByCoordinates(new Vector2((int)targetTileLoc.x, (int)targetTileLoc.z)));
-              
+       
+        if (cardOnTile != null) //if we found an obstacle card under our path during this movement coroutine
+        {
+            StopCoroutine(_currentMovementCoroutine);
+            AddCard?.Invoke(cardOnTile);
+            nextTile.GetObstacleClass().PerformObstacleAnim();
+            //ReachedDestination?.Invoke();
+        }
         ReachedDestination?.Invoke();
     }
     private IEnumerator FallPlayer(Vector3 originTileLoc, Vector3 targetTileLoc)

--- a/Assets/Scripts/Controls/PlayerController.cs
+++ b/Assets/Scripts/Controls/PlayerController.cs
@@ -105,7 +105,7 @@ public class PlayerController : MonoBehaviour
                         Vector3 newV = nextTile.GetPlayerSnapPosition();
                         StartFallCoroutine(transform.position, new Vector3(newV.x, newV.y - 10, newV.z));
                     }
-                    else if (nextTile.GetElevation() < _currentTile.GetElevation()) // going down an elevation level
+                    else if (nextTile.GetElevation() < _currentTile.GetElevation() && !nextTile.IsHole()) // going down an elevation level
                     {
                         StopCoroutine(_currentMovementCoroutine);
                         StartFallCoroutine(transform.position, nextTile.GetPlayerSnapPosition());

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -1,6 +1,6 @@
 // +-----------------------------------------------------------------------------------+
 // @author - Ryan Herwig
-// @Contributers - 
+// @Contributers - Elijah Vroman
 // @Last Modified - October 16th 2024
 // @Description - The engine of the game which controls and initializes everything else
 // +-----------------------------------------------------------------------------------+
@@ -839,7 +839,8 @@ public class GameManager : MonoBehaviour
 
     private void LoadLevelSelect()
     {
-        SceneManager.LoadScene(2);
+        LevelSelect ls = FindObjectOfType<LevelSelect>(false);
+        ls.LoadLevel(ls.GetSceneToGoOnWin());
     }
 
     #region Getters

--- a/Assets/Scripts/StateMachine/PlayerStateMachineBrain.cs
+++ b/Assets/Scripts/StateMachine/PlayerStateMachineBrain.cs
@@ -407,10 +407,12 @@ public class PlayerStateMachineBrain : MonoBehaviour
             yield return new WaitForSeconds(.75f);
             GameManager.TrapAction?.Invoke();
             _firedTraps = true;
-            if (_currentPlayerController.GetTileWithPlayerRaycast() != null && _currentPlayerController.GetTileWithPlayerRaycast().GetObstacleClass() != null)
+            var tile = _currentPlayerController.GetTileWithPlayerRaycast();
+            if (tile != null && tile.GetObstacleClass() != null && tile.GetObstacleClass().IsActive())
             {
+                var temp = _currentPlayerController.GetTileWithPlayerRaycast().GetObstacleClass().GetCard();
                 //get card and check if its not a turn tables
-                if (_currentAction != null && (_currentAction.name != Card.CardName.TurnLeft && _currentAction.name != Card.CardName.TurnRight))
+                if (temp != null && (temp.name != Card.CardName.TurnLeft && temp.name != Card.CardName.TurnRight))
                 {
                     AddCardToList(_currentPlayerController.GetTileWithPlayerRaycast().GetObstacleClass().GetCard());
                 }

--- a/Assets/Scripts/UI/LevelSelect.cs
+++ b/Assets/Scripts/UI/LevelSelect.cs
@@ -1,25 +1,34 @@
 /******************************************************************
 *    Author: Sky Turner
-*    Contributors: 
+*    Contributors: Elijah Vroman
 *    Date Created: 9/5/24
 *    Description: This script loads a scene for level selection
 *******************************************************************/
 
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 public class LevelSelect : MonoBehaviour
 {
+    [SerializeField] private int sceneIndexOnWin;
     /// <summary>
     /// This function loads a scene based on the int passed through
     /// </summary>
     /// <param name="levelNumber">The build index for the scene</param>
-   public void LoadLevel(int levelNumber)
+    public void LoadLevel(int levelNumber)
     {
         Time.timeScale = 1.0f;
         SceneManager.LoadScene(levelNumber);
+    }
+
+
+    /// <summary>
+    /// Public method to return the scene index for gamemanager EV
+    /// </summary>
+    /// <returns></returns>
+    public int GetSceneToGoOnWin()
+    {
+        return sceneIndexOnWin;
     }
 
     public void QuitGame()


### PR DESCRIPTION
I ensured the player now gets to the obstacle's player snap AND waits to add the obstacles card to the action order, which should make turntables work. Please test at least 1 scene of both a speed pad, turntable, and a jump pad. 

Also in the PR I updated the gamemanager so that it gets a reference to the levelselect monobehavior present in each level when deciding which scene to go to on a win. There is a serialized field for the build index to go to.