### PR TITLE
FixedLockedBug

### DIFF
--- a/Assets/Scripts/Managers/CollectibleManager.cs
+++ b/Assets/Scripts/Managers/CollectibleManager.cs
@@ -5,17 +5,15 @@
  *    Description: Collectible Manager 
  *    
  *******************************************************************/
-using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 public class CollectibleManager : MonoBehaviour
 {
-    public static CollectibleManager Instance { get; private set; }
-    private CollectibleStats _collectibleStats;
-
     #region singleton
+    public static CollectibleManager Instance { get; private set; }
     private void Awake()
     {
         if (Instance != null && Instance != this)
@@ -26,11 +24,23 @@ public class CollectibleManager : MonoBehaviour
         {
             Instance = this;
             DontDestroyOnLoad(Instance);
+            _defaultList = collectibleStats.Select(item => item.Clone()).ToList();
         }
     }
     #endregion
 
     public List<CollectibleStats> collectibleStats;
+    private List<CollectibleStats> _defaultList = new List<CollectibleStats>(); //copy list to hold default values
+
+    public List<CollectibleStats> GetDefaultCollectibleList()
+    {
+        return _defaultList;
+    }
+    public List<CollectibleStats> GetEditedCollectibleList()
+    {
+        return collectibleStats;
+    }
+
 
     /// <summary>
     /// Initializes a new instance of the CollectibleManager class.
@@ -48,7 +58,7 @@ public class CollectibleManager : MonoBehaviour
     /// </summary>
     private void InitializeCollectibles()
     {
-        for(int i = 0; i < 30; i++)
+        for (int i = 0; i < 30; i++)
         {
             collectibleStats.Add(new CollectibleStats($"Level {i + 1}", i, true));
         }

--- a/Assets/Scripts/SaveLoad/SaveLoadManager.cs
+++ b/Assets/Scripts/SaveLoad/SaveLoadManager.cs
@@ -7,6 +7,7 @@
 *******************************************************************/
 using System;
 using System.IO;
+using System.Linq;
 using UnityEngine;
 
 public class SaveLoadManager : MonoBehaviour
@@ -112,7 +113,7 @@ public class SaveLoadManager : MonoBehaviour
         if (DoesSaveFileExist(fileToLoad))
         {
             string dir = Application.persistentDataPath + directory;
-            
+
             string jsonString = File.ReadAllText(dir + GetFileNameByInt(fileToLoad));
             temp = JsonUtility.FromJson<SaveData>(jsonString);
             AssignLoadedData(temp);
@@ -123,7 +124,7 @@ public class SaveLoadManager : MonoBehaviour
         else // couldnt find the file, making a new one...
         {
             //Debug.Log("File " + GetFileNameByInt(fileToLoad) + " does not exist when trying to load it, making a new one...");
-            UnAssignLoadedData(temp);
+            UnAssignLoadedData();
             SaveDataToFile(fileToLoad);
         }
         return newData;
@@ -138,20 +139,16 @@ public class SaveLoadManager : MonoBehaviour
         for (int i = 0; i < CollectibleManager.Instance.collectibleStats.Count; i++)
         {
             CollectibleManager.Instance.collectibleStats[i].SetIsLocked(save.levelInformation[i].GetIsLocked());
-            if(save.levelInformation[i].GetIsCollected())
+            if (save.levelInformation[i].GetIsCollected())
             {
                 CollectibleManager.Instance.collectibleStats[i].CollectCollectible();
-            }            
+            }
         }
     }
 
-    public void UnAssignLoadedData(SaveData save)
+    public void UnAssignLoadedData()
     {
-        for(int i = 0; i<CollectibleManager.Instance.collectibleStats.Count; i++)
-        {
-            CollectibleManager.Instance.collectibleStats[i].SetIsLocked(true);
-            CollectibleManager.Instance.collectibleStats[i].SetIsCollected(false);
-        }
+        CollectibleManager.Instance.collectibleStats = CollectibleManager.Instance.GetDefaultCollectibleList().Select(item => item.Clone()).ToList();
     }
 
     /// <summary>
@@ -167,7 +164,7 @@ public class SaveLoadManager : MonoBehaviour
             //Debug.Log("File " + GetFileNameByInt(fileToCheck) + " found");
             return true;
         }
-            
+
         else
         {
             //Debug.Log("File " + GetFileNameByInt(fileToCheck) + " NOT found");

--- a/Assets/Scripts/UI/CollectibleStats.cs
+++ b/Assets/Scripts/UI/CollectibleStats.cs
@@ -47,7 +47,8 @@ public class CollectibleStats
     {
         return new CollectibleStats(_levelName, _buildIndex, _hasCollectible)
         {
-            _isCollected = this._isCollected
+            _isCollected = this._isCollected,
+            _sceneType = this._sceneType
         };
     }
 

--- a/Assets/Scripts/UI/CollectibleStats.cs
+++ b/Assets/Scripts/UI/CollectibleStats.cs
@@ -40,6 +40,18 @@ public class CollectibleStats
     }
 
     /// <summary>
+    /// A method for LINQ to access and make a deep copy of our custom class
+    /// </summary>
+    /// <returns></returns>
+    public CollectibleStats Clone()
+    {
+        return new CollectibleStats(_levelName, _buildIndex, _hasCollectible)
+        {
+            _isCollected = this._isCollected
+        };
+    }
+
+    /// <summary>
     /// Sets the isCollected stat to true
     /// </summary>
     /// <param name="index"></param>


### PR DESCRIPTION
Fixed a bug in the saving and loading that would "lock" the title screen upon starting a new save, preventing you from navigating to it from the back button.

To fix, I had collectiblemanager make a copy of the collectible list (_defaultList), and had collectibleStats include a "clone" method that would return a copy of the class but not the class itself. By doing both of these I could use Linq to iterate over the list when saving and copy it as a deep copy instead of a shallow copy. 

I believe this has fixed the bug. I played the game, completed the first level with the collectible, exited the game, selected a different save, and did not have the collectible. Furthermore, the title screen is no longer locked. 