### PR TITLE
camera speed fix

### DIFF
--- a/Assets/Prefabs/Script Prefabs/CameraContainer.prefab
+++ b/Assets/Prefabs/Script Prefabs/CameraContainer.prefab
@@ -111,7 +111,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _playerInput: {fileID: 2409389655652410456}
   _virtualCamera: {fileID: 7548964786283510077}
-  _cameraSpeedMult: 1
+  _cameraSpeedMult: 10
 --- !u!114 &2409389655652410456
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -417,8 +417,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   virtualCamera: {fileID: 7548964786283510077}
-  frequency: 0
-  amplitude: 0
 --- !u!1 &8829115344087376066
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Controls/CameraController.cs
+++ b/Assets/Scripts/Controls/CameraController.cs
@@ -107,7 +107,11 @@ public class CameraController : MonoBehaviour
     {
         if (_virtualCamera == null) return;
 
+        float direction = 1;
+        if (deltaX < 0)
+            direction = -1;
+
         CinemachineTrackedDolly dolly = _virtualCamera.GetCinemachineComponent<CinemachineTrackedDolly>();
-        dolly.m_PathPosition += deltaX * _cameraSpeedMult * Time.deltaTime * -1;
+        dolly.m_PathPosition += direction * _cameraSpeedMult * Time.deltaTime * -1;
     }
 }


### PR DESCRIPTION
Camera should move smoothly at high speeds with mouse movement. 

Previously the speed was based on the random number from the mouse input, when really all that was needed was if the input was positive or negative. I updated the camera prefab's speed default to 10 which is around where it would usually end up before. And now design can edit the camera speed in each level if the want.